### PR TITLE
HAAR-2385: Fix authorization-code duplicate client endpoint

### DIFF
--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/authorizationapi/service/ClientsInterfaceService.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/authorizationapi/service/ClientsInterfaceService.kt
@@ -146,11 +146,9 @@ class ClientsInterfaceService(
 
     val client = clientsByBaseClientId.last()
 
-    val newClient = clientRepository.findClientByClientId(client.clientId)
-
     val externalClientSecret = oAuthClientSecret.generate()
 
-    val duplicatedRegisteredClient = newClient!!.copy(
+    val duplicatedRegisteredClient = client.copy(
       id = java.util.UUID.randomUUID().toString(),
       clientId = clientIdService.incrementClientId(client.clientId),
       clientIdIssuedAt = Instant.now(),

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/authorizationapi/service/ClientsInterfaceService.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/authorizationapi/service/ClientsInterfaceService.kt
@@ -2,8 +2,6 @@ package uk.gov.justice.digital.hmpps.authorizationapi.service
 
 import org.springframework.core.convert.ConversionService
 import org.springframework.data.repository.findByIdOrNull
-import org.springframework.security.oauth2.server.authorization.client.JdbcRegisteredClientRepository
-import org.springframework.security.oauth2.server.authorization.client.RegisteredClient
 import org.springframework.stereotype.Service
 import org.springframework.transaction.annotation.Transactional
 import uk.gov.justice.digital.hmpps.authorizationapi.adapter.AuthService
@@ -37,7 +35,6 @@ class ClientsInterfaceService(
   private val authorizationConsentRepository: AuthorizationConsentRepository,
   private val clientIdService: ClientIdService,
   private val clientDeploymentRepository: ClientDeploymentRepository,
-  private val registeredClientRepository: JdbcRegisteredClientRepository,
   private val oAuthClientSecret: OAuthClientSecret,
   private val registeredClientAdditionalInformation: RegisteredClientAdditionalInformation,
   private val conversionService: ConversionService,
@@ -148,18 +145,19 @@ class ClientsInterfaceService(
     }
 
     val client = clientsByBaseClientId.last()
-    val registeredClient = registeredClientRepository.findByClientId(client.clientId)
-    val registeredClientBuilder = RegisteredClient.from(registeredClient)
+
+    val newClient = clientRepository.findClientByClientId(client.clientId)
 
     val externalClientSecret = oAuthClientSecret.generate()
-    val duplicatedRegisteredClient = registeredClientBuilder
-      .id(java.util.UUID.randomUUID().toString())
-      .clientId(clientIdService.incrementClientId(client.clientId))
-      .clientIdIssuedAt(Instant.now())
-      .clientSecret(oAuthClientSecret.encode(externalClientSecret))
-      .build()
 
-    registeredClientRepository.save(duplicatedRegisteredClient)
+    val duplicatedRegisteredClient = newClient!!.copy(
+      id = java.util.UUID.randomUUID().toString(),
+      clientId = clientIdService.incrementClientId(client.clientId),
+      clientIdIssuedAt = Instant.now(),
+      clientSecret = oAuthClientSecret.encode(externalClientSecret),
+    )
+
+    clientRepository.save(duplicatedRegisteredClient)
     val authorizationConsent = authorizationConsentRepository.findByIdOrNull(AuthorizationConsentId(client.id, client.clientId))
     authorizationConsent?.let {
       authorizationConsentRepository.save(AuthorizationConsent(duplicatedRegisteredClient.id, duplicatedRegisteredClient.clientId, it.authorities))

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/authorizationapi/integration/ClientsControllerIntTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/authorizationapi/integration/ClientsControllerIntTest.kt
@@ -473,6 +473,70 @@ class ClientsControllerIntTest : IntegrationTestBase() {
 
       clientRepository.delete(duplicatedClient)
     }
+
+    @Test
+    fun `should be able to duplicate authorization code grant type client without redirect url`() {
+      val clientId = "new-auth-client"
+      whenever(oAuthClientSecretGenerator.generate()).thenReturn(clientId)
+      whenever(oAuthClientSecretGenerator.encode(clientId)).thenReturn("encoded-client-secret")
+
+      webTestClient.post().uri("/base-clients")
+        .headers(setAuthorisation(roles = listOf("ROLE_OAUTH_ADMIN")))
+        .body(
+          BodyInserters.fromValue(
+            mapOf(
+              "clientId" to clientId,
+              "grantType" to "authorization_code",
+              "scopes" to listOf("read", "write"),
+              "ips" to listOf("81.134.202.29/32", "35.176.93.186/32"),
+              "databaseUserName" to "testy-mctest",
+              "jiraNumber" to "HAAR-9999",
+              "validDays" to 5,
+              "accessTokenValiditySeconds" to 20,
+              "jwtFields" to "-name",
+              "mfaRememberMe" to true,
+              "mfa" to MfaAccess.ALL,
+            ),
+          ),
+        )
+        .exchange()
+        .expectStatus().isOk
+        .expectBody()
+        .jsonPath("clientId").isEqualTo(clientId)
+        .jsonPath("clientSecret").isEqualTo("new-auth-client")
+        .jsonPath("base64ClientId").isEqualTo(getEncoder().encodeToString(clientId.toByteArray()))
+        .jsonPath("base64ClientSecret").isEqualTo(getEncoder().encodeToString("new-auth-client".toByteArray()))
+
+      whenever(oAuthClientSecretGenerator.generate()).thenReturn("new-auth-client-1")
+      whenever(oAuthClientSecretGenerator.encode("new-auth-client-1")).thenReturn("new-auth-client-1")
+      webTestClient.post().uri("/base-clients/new-auth-client/clients")
+        .headers(setAuthorisation(roles = listOf("ROLE_OAUTH_ADMIN")))
+        .exchange()
+        .expectStatus().isOk
+        .expectBody()
+        .jsonPath("clientId").isEqualTo("new-auth-client-1")
+        .jsonPath("clientSecret").isEqualTo("new-auth-client-1")
+        .jsonPath("base64ClientId").isEqualTo(getEncoder().encodeToString("new-auth-client-1".toByteArray()))
+        .jsonPath("base64ClientSecret").isEqualTo(getEncoder().encodeToString("new-auth-client-1".toByteArray()))
+
+      val originalClient = clientRepository.findClientByClientId("new-auth-client")
+      val duplicatedClient = clientRepository.findClientByClientId("new-auth-client-1")
+      assertThat(duplicatedClient!!.clientName).isEqualTo(originalClient!!.clientName)
+      assertThat(duplicatedClient.redirectUris).isNull()
+      assertThat(duplicatedClient.authorizationGrantTypes).isEqualTo(originalClient.authorizationGrantTypes)
+      assertThat(duplicatedClient.clientAuthenticationMethods).isEqualTo(originalClient.clientAuthenticationMethods)
+      assertThat(duplicatedClient.clientSettings).isEqualTo(originalClient.clientSettings)
+      assertThat(duplicatedClient.tokenSettings).isEqualTo(originalClient.tokenSettings)
+
+      verify(telemetryClient).trackEvent(
+        "AuthorizationApiClientDetailsDuplicated",
+        mapOf("username" to "AUTH_ADM", "clientId" to "new-auth-client-1"),
+        null,
+      )
+
+      clientRepository.delete(duplicatedClient)
+      clientRepository.delete(originalClient)
+    }
   }
 
   @Nested


### PR DESCRIPTION
Fix authorization-code duplicate client when redirect url is null.

Removed 'JdbcRegisteredClientRepository' dependency.