### PR TITLE
Added auth code ttl configuration option

### DIFF
--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/authorizationapi/service/RegisteredClientAdditionalInformation.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/authorizationapi/service/RegisteredClientAdditionalInformation.kt
@@ -1,5 +1,6 @@
 package uk.gov.justice.digital.hmpps.authorizationapi.service
 
+import org.springframework.beans.factory.annotation.Value
 import org.springframework.security.oauth2.jose.jws.SignatureAlgorithm
 import org.springframework.security.oauth2.server.authorization.settings.ClientSettings
 import org.springframework.security.oauth2.server.authorization.settings.TokenSettings
@@ -7,7 +8,9 @@ import org.springframework.stereotype.Component
 import java.time.Duration
 
 @Component
-class RegisteredClientAdditionalInformation {
+class RegisteredClientAdditionalInformation(
+  @Value("\${application.oauth2.authorizationcode.timetolive}") val authorizationCodeTTL: String?,
+) {
 
   companion object {
     private const val CLIENT_ADDITIONAL_DATA = "settings.client.additional-data."
@@ -15,13 +18,20 @@ class RegisteredClientAdditionalInformation {
     const val DATABASE_USER_NAME_KEY = CLIENT_ADDITIONAL_DATA + "database-user-name"
     const val JWT_FIELDS_NAME_KEY = CLIENT_ADDITIONAL_DATA + "jwtFields"
     const val CLAIMS_JIRA_NUMBER = "jira_number"
+    const val AUTH_CODE_TTL_DEFAULT_DURATION = "PT5M"
   }
 
   fun buildTokenSettings(accessTokenValiditySeconds: Long?): TokenSettings {
-    val tokenSettingsBuilder = TokenSettings.builder().idTokenSignatureAlgorithm(SignatureAlgorithm.RS256)
+    val tokenSettingsBuilder = TokenSettings.builder()
+      .idTokenSignatureAlgorithm(SignatureAlgorithm.RS256)
+
     accessTokenValiditySeconds?.let {
       tokenSettingsBuilder.accessTokenTimeToLive(Duration.ofSeconds(it))
     }
+
+    // Spring defaults to 5 minutes if no value is explicitly set. Maintain this behaviour is no override is present
+    val authCodeTTLDuration = authorizationCodeTTL?.trim()?.ifEmpty { AUTH_CODE_TTL_DEFAULT_DURATION } ?: AUTH_CODE_TTL_DEFAULT_DURATION
+    tokenSettingsBuilder.authorizationCodeTimeToLive(Duration.parse(authCodeTTLDuration))
 
     return tokenSettingsBuilder.build()
   }

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/authorizationapi/service/RegisteredClientAdditionalInformation.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/authorizationapi/service/RegisteredClientAdditionalInformation.kt
@@ -29,7 +29,7 @@ class RegisteredClientAdditionalInformation(
       tokenSettingsBuilder.accessTokenTimeToLive(Duration.ofSeconds(it))
     }
 
-    // Spring defaults to 5 minutes if no value is explicitly set. Maintain this behaviour is no override is present
+    // Spring defaults to 5 minutes if no value is explicitly set. Maintain this behaviour if no override is present
     val authCodeTTLDuration = authorizationCodeTTL?.trim()?.ifEmpty { AUTH_CODE_TTL_DEFAULT_DURATION } ?: AUTH_CODE_TTL_DEFAULT_DURATION
     tokenSettingsBuilder.authorizationCodeTimeToLive(Duration.parse(authCodeTTLDuration))
 

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -107,3 +107,6 @@ application:
       remove-access-tokens: 0 0 23 * * * # daily at 23:00 hours
       remove-expired-auth-codes: 0 0 0 * * 0  # once a week
       remove-expired-user-details: 0 0/30 23 * * * # daily at 23:30 hours
+  oauth2:
+    authorization-code:
+      time-to-live: PT5M # Spring default to 5 minutes if no override is provided. For visibility explicitly apply default here.

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/authorizationapi/integration/ClientsControllerIntTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/authorizationapi/integration/ClientsControllerIntTest.kt
@@ -721,6 +721,7 @@ class ClientsControllerIntTest : IntegrationTestBase() {
       assertThat(client.authorizationGrantTypes).isEqualTo(GrantType.client_credentials.name)
       assertThat(client.scopes).contains("read", "write")
       assertThat(client.tokenSettings.accessTokenTimeToLive).isEqualTo(Duration.ofSeconds(20))
+      assertThat(client.tokenSettings.authorizationCodeTimeToLive).isEqualTo(Duration.ofMinutes(5))
       assertThat(registeredClientAdditionalInformation.getDatabaseUserName(client.clientSettings)).contains("testy-mctest")
       assertThat(registeredClientAdditionalInformation.getJiraNumber(client.clientSettings)).isEqualTo("HAAR-9999")
       assertThat(client.skipToAzure).isTrue

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/authorizationapi/integration/OAuthIntTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/authorizationapi/integration/OAuthIntTest.kt
@@ -352,8 +352,9 @@ class OAuthIntTest : IntegrationTestBase() {
       val groups: MatchResult? = ".*code=(.*)&state=.*".toRegex().find(location.responseHeaders.location!!.toString())
       assertThat(groups).isNotNull
       assertThat(groups!!.groupValues).hasSizeGreaterThan(1)
-      val code = groups.groups[1]?.value
+      assertThat(groups.groups[1]?.value).isNotNull
 
+      val code = groups.groups[1]!!.value
       val authCodeToken = userAuthenticationService.findByToken(code, OAuth2TokenType(OAuth2ParameterNames.CODE))?.let {
         it.getToken(OAuth2AuthorizationCode::class.java)?.token
       }

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/authorizationapi/integration/TokenSettingsAuthorizationCodeTimeToLiveConfigTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/authorizationapi/integration/TokenSettingsAuthorizationCodeTimeToLiveConfigTest.kt
@@ -61,13 +61,10 @@ class TokenSettingsAuthorizationCodeTimeToLiveConfigTest : IntegrationTestBase()
   @AfterEach
   fun tearDown() {
     clientRepository.findClientByClientId(CLIENT_ID)?.let {
-      println("deleting client ${it.clientId}")
       clientRepository.deleteByClientId(it.clientId)
 
-      println("deleting clientConfig ${it.clientId}")
       clientConfigRepository.deleteByBaseClientId(it.clientId)
 
-      println("deleting auth consent ${it.id}/ ${it.clientName}")
       authorizationConsentRepository.deleteById(
         AuthorizationConsent.AuthorizationConsentId(it.id, it.clientName),
       )

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/authorizationapi/integration/TokenSettingsAuthorizationCodeTimeToLiveConfigTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/authorizationapi/integration/TokenSettingsAuthorizationCodeTimeToLiveConfigTest.kt
@@ -1,0 +1,125 @@
+package uk.gov.justice.digital.hmpps.authorizationapi.integration
+
+import org.assertj.core.api.Assertions.assertThat
+import org.junit.jupiter.api.AfterEach
+import org.junit.jupiter.api.Assertions.assertNotNull
+import org.junit.jupiter.api.Assertions.assertNull
+import org.junit.jupiter.api.Test
+import org.mockito.kotlin.whenever
+import org.springframework.beans.factory.annotation.Autowired
+import org.springframework.boot.test.mock.mockito.MockBean
+import org.springframework.test.context.TestPropertySource
+import org.springframework.transaction.annotation.Transactional
+import org.springframework.web.reactive.function.BodyInserters
+import uk.gov.justice.digital.hmpps.authorizationapi.data.model.AuthorizationConsent
+import uk.gov.justice.digital.hmpps.authorizationapi.data.model.Client
+import uk.gov.justice.digital.hmpps.authorizationapi.data.repository.AuthorizationConsentRepository
+import uk.gov.justice.digital.hmpps.authorizationapi.data.repository.ClientConfigRepository
+import uk.gov.justice.digital.hmpps.authorizationapi.data.repository.ClientRepository
+import uk.gov.justice.digital.hmpps.authorizationapi.utils.OAuthClientSecret
+import java.time.Duration
+import java.util.Base64.getEncoder
+import kotlin.streams.asSequence
+
+/**
+ * Test verifies that [Client.tokenSettings].authorizationCodeTimeToLive config can be overridden in
+ * application properties
+ */
+@Transactional
+@TestPropertySource(
+  properties = [
+    "application.oauth2.authorizationcode.timetolive=PT13M",
+  ],
+)
+class TokenSettingsAuthorizationCodeTimeToLiveConfigTest : IntegrationTestBase() {
+
+  @Autowired
+  lateinit var clientRepository: ClientRepository
+
+  @Autowired
+  lateinit var clientConfigRepository: ClientConfigRepository
+
+  @Autowired
+  lateinit var authorizationConsentRepository: AuthorizationConsentRepository
+
+  @MockBean
+  lateinit var oAuthClientSecretGenerator: OAuthClientSecret
+
+  companion object {
+    private const val CLIENT_ID_CHARSET = "abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ"
+    private val CLIENT_ID = "test-client-${randomString()}"
+
+    private fun randomString(): String {
+      return java.util.Random()
+        .ints(10, 0, CLIENT_ID_CHARSET.length)
+        .asSequence()
+        .map(CLIENT_ID_CHARSET::get)
+        .joinToString("")
+    }
+  }
+
+  @AfterEach
+  fun tearDown() {
+    clientRepository.findClientByClientId(CLIENT_ID)?.let {
+      println("deleting client ${it.clientId}")
+      clientRepository.deleteByClientId(it.clientId)
+
+      println("deleting clientConfig ${it.clientId}")
+      clientConfigRepository.deleteByBaseClientId(it.clientId)
+
+      println("deleting auth consent ${it.id}/ ${it.clientName}")
+      authorizationConsentRepository.deleteById(
+        AuthorizationConsent.AuthorizationConsentId(it.id, it.clientName),
+      )
+    }
+    assertThat(clientRepository.findClientByClientId(CLIENT_ID)).isNull()
+  }
+
+  /**
+   * Test overrides the default [Client.tokenSettings#authorizationCodeTimeToLive] configuration, creates a new client
+   * and verifies the client.tokensettings contain the expected auth code ttl value.
+   **/
+  @Test
+  fun `create client sets expected tokenSettings authorizationCodeTimeToLive when override is provided in application properties`() {
+    assertNull(clientRepository.findClientByClientId(CLIENT_ID))
+
+    whenever(oAuthClientSecretGenerator.generate())
+      .thenReturn("external-client-secret")
+
+    whenever(oAuthClientSecretGenerator.encode("external-client-secret"))
+      .thenReturn("encoded-client-secret")
+
+    webTestClient.post().uri("/base-clients")
+      .headers(setAuthorisation(roles = listOf("ROLE_OAUTH_ADMIN")))
+      .body(
+        BodyInserters.fromValue(
+          mapOf(
+            "clientId" to CLIENT_ID,
+            "grantType" to "authorization_code",
+            "scopes" to listOf("read", "write"),
+            "authorities" to emptyList<String>(),
+            "ips" to listOf("81.134.202.29/32", "35.176.93.186/32"),
+            "databaseUserName" to "testy-mctest",
+            "jiraNumber" to "HAAR-9999",
+            "validDays" to 5,
+            "accessTokenValiditySeconds" to 20,
+            "skipToAzure" to true,
+            "resourceIds" to emptyList<String>(),
+          ),
+        ),
+      )
+      .exchange()
+      .expectStatus().isOk
+      .expectBody()
+      .jsonPath("clientId").isEqualTo(CLIENT_ID)
+      .jsonPath("clientSecret").isEqualTo("external-client-secret")
+      .jsonPath("base64ClientId").isEqualTo(getEncoder().encodeToString(CLIENT_ID.toByteArray()))
+      .jsonPath("base64ClientSecret").isEqualTo(getEncoder().encodeToString("external-client-secret".toByteArray()))
+
+    val client: Client? = clientRepository.findClientByClientId(CLIENT_ID)
+
+    assertNotNull(client)
+    assertThat(client!!.tokenSettings).isNotNull
+    assertThat(client.tokenSettings.authorizationCodeTimeToLive).isEqualTo(Duration.ofMinutes(13))
+  }
+}

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/authorizationapi/service/RegisteredClientAdditionalInformationTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/authorizationapi/service/RegisteredClientAdditionalInformationTest.kt
@@ -1,0 +1,71 @@
+package uk.gov.justice.digital.hmpps.authorizationapi.service
+
+import org.assertj.core.api.Assertions.assertThat
+import org.junit.jupiter.api.Test
+import org.junit.jupiter.api.assertThrows
+import org.junit.jupiter.params.ParameterizedTest
+import org.junit.jupiter.params.provider.MethodSource
+import java.time.Duration
+import java.time.format.DateTimeParseException
+
+class RegisteredClientAdditionalInformationTest {
+
+  private lateinit var registeredClientAdditionalInfo: RegisteredClientAdditionalInformation
+
+  @ParameterizedTest
+  @MethodSource("uk.gov.justice.digital.hmpps.authorizationapi.service.RegisteredClientAdditionalInformationTest#testCases")
+  fun `buildTokenSettings configures authorizationCodeTimeToLive with the expected value`(testCase: TestCase) {
+    registeredClientAdditionalInfo = RegisteredClientAdditionalInformation(testCase.authorizationCodeTTL)
+
+    val tokenSettings = registeredClientAdditionalInfo.buildTokenSettings(1)
+
+    assertThat(tokenSettings).isNotNull
+    assertThat(tokenSettings.authorizationCodeTimeToLive).isEqualTo(testCase.expectedDuration)
+  }
+
+  @Test
+  fun `buildTokenSettings throws the expected exception when authorizationCodeTimeToLive is not a valid duration string`() {
+    registeredClientAdditionalInfo = RegisteredClientAdditionalInformation("this 1s n0t a V4l1d duration strinG!!")
+
+    assertThrows<DateTimeParseException> { registeredClientAdditionalInfo.buildTokenSettings(1) }
+  }
+
+  data class TestCase(
+    val description: String,
+    val authorizationCodeTTL: String?,
+    val expectedDuration: Duration,
+  )
+
+  companion object {
+    private val DEFAULT_DURATION = Duration.ofMinutes(5)
+
+    @JvmStatic
+    fun testCases() = listOf(
+      TestCase(
+        description = "authorizationCodeTimeToLive defaults to 5 minutes if authorizationCodeTTL is null",
+        authorizationCodeTTL = null,
+        expectedDuration = DEFAULT_DURATION,
+      ),
+      TestCase(
+        description = "authorizationCodeTimeToLive defaults to 5 minutes if authorizationCodeTTL is empty",
+        authorizationCodeTTL = "",
+        expectedDuration = DEFAULT_DURATION,
+      ),
+      TestCase(
+        description = "authorizationCodeTimeToLive defaults to 5 minutes if authorizationCodeTTL is empty with multiple spaces",
+        authorizationCodeTTL = "    ",
+        expectedDuration = DEFAULT_DURATION,
+      ),
+      TestCase(
+        description = "authorizationCodeTimeToLive is set to the provided duration when authorizationCodeTTL is a valid duration with whitespace",
+        authorizationCodeTTL = " PT20M ",
+        expectedDuration = Duration.ofMinutes(20),
+      ),
+      TestCase(
+        description = "authorizationCodeTimeToLive is set to the provided duration when authorizationCodeTTL is a valid duration",
+        authorizationCodeTTL = "PT10M",
+        expectedDuration = Duration.ofMinutes(10),
+      ),
+    )
+  }
+}


### PR DESCRIPTION
Added new configuration option to allow customisation of `authorization-client.tokensettings.authorizationCodeTTL`. Maintains the Spring default of 5mins if no value is set.