### PR TITLE
HAAR-3532: Add client for hmpps-authorization UI 

### DIFF
--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/authorizationapi/data/model/Authorization.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/authorizationapi/data/model/Authorization.kt
@@ -1,6 +1,7 @@
 package uk.gov.justice.digital.hmpps.authorizationapi.data.model
 
 import jakarta.persistence.Column
+import jakarta.persistence.Convert
 import jakarta.persistence.Entity
 import jakarta.persistence.Id
 import jakarta.persistence.Table
@@ -20,11 +21,14 @@ data class Authorization(
   private val authorizationGrantType: String,
 
   @Column(name = "access_token_issued_at")
+  @Convert(converter = InstantConverter::class)
   var accessTokenIssuedAt: Instant?,
 
   @Column(name = "authorization_code_issued_at")
+  @Convert(converter = InstantConverter::class)
   var authorizationCodeIssuedAt: Instant?,
 
   @Column(name = "authorization_code_expires_at")
+  @Convert(converter = InstantConverter::class)
   var authorizationCodeExpiresAt: Instant?,
 )

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/authorizationapi/data/model/Client.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/authorizationapi/data/model/Client.kt
@@ -24,10 +24,12 @@ data class Client(
 
   var clientId: String,
 
+  @Convert(converter = InstantConverter::class)
   val clientIdIssuedAt: Instant,
 
   var clientSecret: String? = null,
 
+  @Convert(converter = InstantConverter::class)
   val clientSecretExpiresAt: Instant? = null,
 
   var clientName: String,

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/authorizationapi/data/model/UserAuthorizationCode.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/authorizationapi/data/model/UserAuthorizationCode.kt
@@ -43,8 +43,8 @@ class AuthSourceConverter : AttributeConverter<AuthSource, String> {
 }
 
 @Converter
-class InstantConverter : AttributeConverter<Instant, Timestamp> {
-  override fun convertToDatabaseColumn(source: Instant): Timestamp = Timestamp.from(source)
+object InstantConverter : AttributeConverter<Instant?, Timestamp?> {
+  override fun convertToDatabaseColumn(source: Instant?): Timestamp? = source?.let { Timestamp.from(it) }
 
-  override fun convertToEntityAttribute(persistedValue: Timestamp): Instant = persistedValue.toInstant()
+  override fun convertToEntityAttribute(persistedValue: Timestamp?): Instant? = persistedValue?.toInstant()
 }

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/authorizationapi/service/ClientDataService.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/authorizationapi/service/ClientDataService.kt
@@ -11,7 +11,8 @@ import uk.gov.justice.digital.hmpps.authorizationapi.data.repository.ClientRepos
 import uk.gov.justice.digital.hmpps.authorizationapi.resource.ClientDetailsResponse
 import uk.gov.justice.digital.hmpps.authorizationapi.resource.ClientLastAccessedResponse
 import java.time.LocalDate
-import java.time.ZoneId
+import java.time.LocalDateTime
+import java.time.ZoneOffset
 
 @Service
 class ClientDataService(
@@ -31,7 +32,7 @@ class ClientDataService(
     clientRepository.findAll().map {
       ClientLastAccessedResponse(
         it.clientId,
-        it.getLastAccessedDate().atZone(ZoneId.systemDefault()).toLocalDateTime(),
+        LocalDateTime.ofInstant(it.getLastAccessedDate(), ZoneOffset.UTC),
       )
     }
 

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -30,6 +30,12 @@ spring:
   codec:
     max-in-memory-size: 10MB
 
+  jpa:
+    properties:
+      hibernate:
+        jdbc:
+          time_zone: UTC
+
   jackson:
     date-format: "yyyy-MM-dd HH:mm:ss"
     serialization:

--- a/src/main/resources/db/dev/data/V900_0__registered_clients.sql
+++ b/src/main/resources/db/dev/data/V900_0__registered_clients.sql
@@ -55,7 +55,7 @@ VALUES
      '{"@class":"java.util.Collections$UnmodifiableMap","settings.token.reuse-refresh-tokens":true,"settings.token.id-token-signature-algorithm":["org.springframework.security.oauth2.jose.jws.SignatureAlgorithm","RS256"],"settings.token.authorization-code-time-to-live":["java.time.Duration",1200.000000000],"settings.token.additional-data.jira-number":"HAAR-9999","settings.token.access-token-time-to-live":["java.time.Duration",300.000000000],"settings.token.access-token-format":{"@class":"org.springframework.security.oauth2.server.authorization.settings.OAuth2TokenFormat","value":"self-contained"}}',
      null, false,'http://127.0.0.1:8089/'),
 
-    ('ceab6c18-081b-44e9-8130-3b37a2541089', 'hmpps-auth-authorization-api-client', current_timestamp, '{bcrypt}$2a$10$KeuHCVZ4DmBiaM6zvy9OzO2Ze/zFkCc9DrHSHq9Y8LiP0o3ZIHk9S', null, 'hmpps-auth-authorization-api-client',
+    ('ceab6c18-081b-44e9-8130-3b37a2541089', 'hmpps-auth-authorization-api-client', current_timestamp, '{bcrypt}$2a$10$8WrQGV5DYDlGiPGY3YZPyeQWooHDpmZ.xK6NKhl1Q90a9Zx4SLSz6', null, 'hmpps-auth-authorization-api-client',
      'client_secret_basic', 'client_credentials', null, 'read,write',
      '{"@class":"java.util.Collections$UnmodifiableMap","settings.client.require-proof-key":false,"settings.client.require-authorization-consent":false,"settings.client.additional-data.jira-number":"HAAR-9999","settings.client.additional-data.database-user-name":"testy-db"}',
      '{"@class":"java.util.Collections$UnmodifiableMap","settings.token.reuse-refresh-tokens":true,"settings.token.id-token-signature-algorithm":["org.springframework.security.oauth2.jose.jws.SignatureAlgorithm","RS256"],"settings.token.access-token-time-to-live":["java.time.Duration",1200.000000000],"settings.token.access-token-format":{"@class":"org.springframework.security.oauth2.server.authorization.settings.OAuth2TokenFormat","value":"self-contained"},"settings.token.refresh-token-time-to-live":["java.time.Duration",600.000000000]}',null, false, null),
@@ -77,7 +77,14 @@ VALUES
      'client_secret_basic', 'authorization_code', 'http://127.0.0.1:8089/login/oauth2/code/oidc-client,https://oauth.pstmn.io/v1/callback', 'read',
      '{"@class":"java.util.Collections$UnmodifiableMap","settings.client.require-proof-key":false,"settings.client.require-authorization-consent":false}',
      '{"@class":"java.util.Collections$UnmodifiableMap","settings.token.reuse-refresh-tokens":true,"settings.token.id-token-signature-algorithm":["org.springframework.security.oauth2.jose.jws.SignatureAlgorithm","RS256"],"settings.token.authorization-code-time-to-live":["java.time.Duration",1200.000000000],"settings.token.additional-data.jira-number":"HAAR-9999","settings.token.access-token-time-to-live":["java.time.Duration",300.000000000],"settings.token.access-token-format":{"@class":"org.springframework.security.oauth2.server.authorization.settings.OAuth2TokenFormat","value":"self-contained"}}',
+     null, false,'http://127.0.0.1:8089/'),
+
+    ('39c59dec-50b8-49f3-8d57-7dfbea34dd29', 'hmpps-authorization-client', current_timestamp, '{bcrypt}$2a$10$iItP8qu7ocHyw92687SKAehZQb7MhCjU6g37OGUt1I0guEE7B.4ba', null, 'hmpps-authorization-client',
+     'client_secret_basic', 'authorization_code', 'http://localhost:3002/sign-in/callback,http://localhost:3002,http://localhost:3002/', 'read',
+     '{"@class":"java.util.Collections$UnmodifiableMap","settings.client.require-proof-key":false,"settings.client.require-authorization-consent":false}',
+     '{"@class":"java.util.Collections$UnmodifiableMap","settings.token.reuse-refresh-tokens":true,"settings.token.id-token-signature-algorithm":["org.springframework.security.oauth2.jose.jws.SignatureAlgorithm","RS256"],"settings.token.authorization-code-time-to-live":["java.time.Duration",1200.000000000],"settings.token.additional-data.jira-number":"HAAR-9999","settings.token.access-token-time-to-live":["java.time.Duration",300.000000000],"settings.token.access-token-format":{"@class":"org.springframework.security.oauth2.server.authorization.settings.OAuth2TokenFormat","value":"self-contained"}}',
      null, false,'http://127.0.0.1:8089/');
+
 
 INSERT INTO oauth2_client_config (base_client_id, allowed_ips, client_end_date)
 VALUES

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/authorizationapi/data/model/InstantConverterTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/authorizationapi/data/model/InstantConverterTest.kt
@@ -1,0 +1,37 @@
+package uk.gov.justice.digital.hmpps.authorizationapi.data.model
+
+import org.junit.jupiter.api.Assertions.assertEquals
+import org.junit.jupiter.api.Assertions.assertNull
+import org.junit.jupiter.api.Test
+import java.sql.Timestamp
+import java.time.Instant
+
+internal class InstantConverterTest {
+  @Test
+  fun `converts a Timestamp to an Instant`() {
+    val instant = Instant.now()
+    val timestamp = Timestamp.from(instant)
+    val actualInstant = InstantConverter.convertToEntityAttribute(timestamp)
+    assertEquals(instant, actualInstant)
+  }
+
+  @Test
+  fun `converts an Instant to a Timestamp`() {
+    val instant = Instant.now()
+    val timestamp = Timestamp.from(instant)
+    val actualTimestamp = InstantConverter.convertToDatabaseColumn(instant)
+    assertEquals(timestamp, actualTimestamp)
+  }
+
+  @Test
+  fun `converts a null Timestamp to a null Instant`() {
+    val actualInstant = InstantConverter.convertToEntityAttribute(null)
+    assertNull(actualInstant)
+  }
+
+  @Test
+  fun `converts a null Instant to a null Timestamp`() {
+    val actualTimestamp = InstantConverter.convertToDatabaseColumn(null)
+    assertNull(actualTimestamp)
+  }
+}

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/authorizationapi/integration/ClientsDataControllerIntTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/authorizationapi/integration/ClientsDataControllerIntTest.kt
@@ -42,7 +42,7 @@ class ClientsDataControllerIntTest : IntegrationTestBase() {
         .expectStatus().isOk
         .expectHeader().contentType(MediaType.APPLICATION_JSON)
         .expectBody()
-        .jsonPath("$.[*]").value<List<String>> { assertThat(it).hasSize(14) }
+        .jsonPath("$.[*]").value<List<String>> { assertThat(it).hasSize(15) }
         .jsonPath("\$.[0].clientId").isEqualTo("test-client-id")
         .jsonPath("\$.[0].scopes[0]").isEqualTo("read")
         .jsonPath("\$.[0].scopes[1]").isEqualTo("write")
@@ -129,7 +129,7 @@ class ClientsDataControllerIntTest : IntegrationTestBase() {
         .expectStatus().isOk
         .expectHeader().contentType(MediaType.APPLICATION_JSON)
         .expectBody()
-        .jsonPath("$.[*]").value<List<String>> { assertThat(it).hasSize(14) }
+        .jsonPath("$.[*]").value<List<String>> { assertThat(it).hasSize(15) }
         .jsonPath("\$.[0].clientId").isEqualTo("test-client-id")
         .jsonPath("\$.[0].lastAccessed").isEqualTo("2024-08-22T11:30:30")
         .jsonPath("\$.[1].clientId").isEqualTo("test-client-create-id")

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/authorizationapi/integration/ClientsInterfaceControllerIntTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/authorizationapi/integration/ClientsInterfaceControllerIntTest.kt
@@ -14,11 +14,11 @@ import org.mockito.kotlin.verify
 import org.mockito.kotlin.verifyNoInteractions
 import org.mockito.kotlin.whenever
 import org.springframework.beans.factory.annotation.Autowired
-import org.springframework.boot.test.mock.mockito.MockBean
 import org.springframework.data.repository.findByIdOrNull
 import org.springframework.http.HttpStatus
 import org.springframework.http.MediaType
 import org.springframework.security.oauth2.server.authorization.client.JdbcRegisteredClientRepository
+import org.springframework.test.context.bean.override.mockito.MockitoBean
 import org.springframework.web.reactive.function.BodyInserters
 import uk.gov.justice.digital.hmpps.authorizationapi.adapter.AuthService
 import uk.gov.justice.digital.hmpps.authorizationapi.adapter.ServiceDetails
@@ -56,13 +56,13 @@ class ClientsInterfaceControllerIntTest : IntegrationTestBase() {
   @Autowired
   lateinit var clientDeploymentRepository: ClientDeploymentRepository
 
-  @MockBean
+  @MockitoBean
   lateinit var oAuthClientSecretGenerator: OAuthClientSecret
 
-  @MockBean
+  @MockitoBean
   lateinit var authService: AuthService
 
-  @MockBean
+  @MockitoBean
   private lateinit var telemetryClient: TelemetryClient
 
   @Autowired

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/authorizationapi/integration/ClientsInterfaceControllerIntTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/authorizationapi/integration/ClientsInterfaceControllerIntTest.kt
@@ -103,21 +103,21 @@ class ClientsInterfaceControllerIntTest : IntegrationTestBase() {
         .expectBody()
         .jsonPath("$.clients[0].baseClientId").isEqualTo("expiry-test-client")
         .jsonPath("$.clients[0].expired").isEqualTo("EXPIRED")
-        .jsonPath("$.clients[7].baseClientId").isEqualTo("test-client-create-id")
-        .jsonPath("$.clients[7].clientType").isEqualTo("PERSONAL")
-        .jsonPath("$.clients[7].teamName").isEqualTo("HAAR")
-        .jsonPath("$.clients[7].grantType").isEqualTo("client_credentials")
-        .jsonPath("$.clients[7].roles").isEqualTo(
+        .jsonPath("$.clients[8].baseClientId").isEqualTo("test-client-create-id")
+        .jsonPath("$.clients[8].clientType").isEqualTo("PERSONAL")
+        .jsonPath("$.clients[8].teamName").isEqualTo("HAAR")
+        .jsonPath("$.clients[8].grantType").isEqualTo("client_credentials")
+        .jsonPath("$.clients[8].roles").isEqualTo(
           "AUDIT\n" +
             "OAUTH_ADMIN\nTESTING\nVIEW_AUTH_SERVICE_DETAILS",
         )
         .jsonPath("$.clients[6].count").isEqualTo(1)
         .jsonPath("$.clients[6].expired").isEmpty
-        .jsonPath("\$.clients[8].baseClientId").isEqualTo("test-client-id")
-        .jsonPath("\$.clients[8].lastAccessed").isEqualTo("2024-08-22T11:30:30Z")
-        .jsonPath("\$.clients[5].baseClientId").isEqualTo("test-auth-code-client")
-        .jsonPath("\$.clients[5].lastAccessed").isEqualTo("2024-08-19T18:36:27Z")
-        .jsonPath("$.clients[*].baseClientId").value<List<String>> { assertThat(it).hasSize(13) }
+        .jsonPath("\$.clients[9].baseClientId").isEqualTo("test-client-id")
+        .jsonPath("\$.clients[9].lastAccessed").isEqualTo("2024-08-22T11:30:30Z")
+        .jsonPath("\$.clients[6].baseClientId").isEqualTo("test-auth-code-client")
+        .jsonPath("\$.clients[6].lastAccessed").isEqualTo("2024-08-19T18:36:27Z")
+        .jsonPath("$.clients[*].baseClientId").value<List<String>> { assertThat(it).hasSize(14) }
         .jsonPath("$.clients[*].baseClientId").value<List<String>> {
           assertThat(it).containsAll(
             listOf(
@@ -134,6 +134,7 @@ class ClientsInterfaceControllerIntTest : IntegrationTestBase() {
               "test-duplicate-id",
               "url-encode-auth-code",
               "url-encode-client-credentials",
+              "hmpps-authorization-client",
             ),
           )
         }

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/authorizationapi/integration/MigrationControllerIntTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/authorizationapi/integration/MigrationControllerIntTest.kt
@@ -9,7 +9,7 @@ import org.junit.jupiter.api.Nested
 import org.junit.jupiter.api.Test
 import org.mockito.kotlin.verify
 import org.springframework.beans.factory.annotation.Autowired
-import org.springframework.boot.test.mock.mockito.MockBean
+import org.springframework.test.context.bean.override.mockito.MockitoBean
 import org.springframework.web.reactive.function.BodyInserters
 import uk.gov.justice.digital.hmpps.authorizationapi.data.model.AuthorizationConsent
 import uk.gov.justice.digital.hmpps.authorizationapi.data.model.ClientType
@@ -40,7 +40,7 @@ class MigrationControllerIntTest : IntegrationTestBase() {
   @Autowired
   lateinit var clientDeploymentRepository: ClientDeploymentRepository
 
-  @MockBean
+  @MockitoBean
   private lateinit var telemetryClient: TelemetryClient
 
   @Nested

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/authorizationapi/integration/OAuthIntTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/authorizationapi/integration/OAuthIntTest.kt
@@ -14,13 +14,13 @@ import org.junit.jupiter.api.Nested
 import org.junit.jupiter.api.Test
 import org.mockito.kotlin.verify
 import org.springframework.beans.factory.annotation.Autowired
-import org.springframework.boot.test.mock.mockito.MockBean
 import org.springframework.http.HttpHeaders
 import org.springframework.http.MediaType.APPLICATION_FORM_URLENCODED
 import org.springframework.security.oauth2.core.endpoint.OAuth2ParameterNames
 import org.springframework.security.oauth2.server.authorization.OAuth2AuthorizationCode
 import org.springframework.security.oauth2.server.authorization.OAuth2AuthorizationService
 import org.springframework.security.oauth2.server.authorization.OAuth2TokenType
+import org.springframework.test.context.bean.override.mockito.MockitoBean
 import org.springframework.util.LinkedMultiValueMap
 import org.springframework.web.reactive.function.BodyInserters.fromFormData
 import uk.gov.justice.digital.hmpps.authorizationapi.resource.GrantType
@@ -44,7 +44,7 @@ class OAuthIntTest : IntegrationTestBase() {
   @Autowired
   private lateinit var oAuthClientSecret: OAuthClientSecret
 
-  @MockBean
+  @MockitoBean
   private lateinit var telemetryClient: TelemetryClient
 
   @Nested

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/authorizationapi/integration/RotateClientsControllerIntTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/authorizationapi/integration/RotateClientsControllerIntTest.kt
@@ -11,9 +11,9 @@ import org.junit.jupiter.api.Test
 import org.mockito.kotlin.verify
 import org.mockito.kotlin.whenever
 import org.springframework.beans.factory.annotation.Autowired
-import org.springframework.boot.test.mock.mockito.MockBean
 import org.springframework.data.repository.findByIdOrNull
 import org.springframework.http.HttpStatus
+import org.springframework.test.context.bean.override.mockito.MockitoBean
 import org.springframework.web.reactive.function.BodyInserters
 import uk.gov.justice.digital.hmpps.authorizationapi.data.model.AuthorizationConsent
 import uk.gov.justice.digital.hmpps.authorizationapi.data.model.AuthorizationConsent.AuthorizationConsentId
@@ -38,10 +38,10 @@ class RotateClientsControllerIntTest : IntegrationTestBase() {
   @Autowired
   lateinit var clientDeploymentRepository: ClientDeploymentRepository
 
-  @MockBean
+  @MockitoBean
   lateinit var oAuthClientSecretGenerator: OAuthClientSecret
 
-  @MockBean
+  @MockitoBean
   private lateinit var telemetryClient: TelemetryClient
 
   @Nested

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/authorizationapi/integration/TokenSettingsAuthorizationCodeTimeToLiveConfigTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/authorizationapi/integration/TokenSettingsAuthorizationCodeTimeToLiveConfigTest.kt
@@ -7,8 +7,8 @@ import org.junit.jupiter.api.Assertions.assertNull
 import org.junit.jupiter.api.Test
 import org.mockito.kotlin.whenever
 import org.springframework.beans.factory.annotation.Autowired
-import org.springframework.boot.test.mock.mockito.MockBean
 import org.springframework.test.context.TestPropertySource
+import org.springframework.test.context.bean.override.mockito.MockitoBean
 import org.springframework.transaction.annotation.Transactional
 import org.springframework.web.reactive.function.BodyInserters
 import uk.gov.justice.digital.hmpps.authorizationapi.data.model.AuthorizationConsent
@@ -42,7 +42,7 @@ class TokenSettingsAuthorizationCodeTimeToLiveConfigTest : IntegrationTestBase()
   @Autowired
   lateinit var authorizationConsentRepository: AuthorizationConsentRepository
 
-  @MockBean
+  @MockitoBean
   lateinit var oAuthClientSecretGenerator: OAuthClientSecret
 
   companion object {

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/authorizationapi/integration/health/HealthCheckTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/authorizationapi/integration/health/HealthCheckTest.kt
@@ -4,7 +4,7 @@ import org.assertj.core.api.Assertions.assertThat
 import org.junit.jupiter.api.Test
 import org.mockito.kotlin.whenever
 import org.springframework.boot.actuate.health.Health
-import org.springframework.boot.test.mock.mockito.MockBean
+import org.springframework.test.context.bean.override.mockito.MockitoBean
 import uk.gov.justice.digital.hmpps.authorizationapi.health.AuthHealthInfo
 import uk.gov.justice.digital.hmpps.authorizationapi.integration.IntegrationTestBase
 import java.time.LocalDateTime
@@ -13,7 +13,7 @@ import java.util.function.Consumer
 
 class HealthCheckTest : IntegrationTestBase() {
 
-  @MockBean
+  @MockitoBean
   lateinit var authHealthInfo: AuthHealthInfo
 
   @Test


### PR DESCRIPTION
This is needed for running auth locally from docker compose, which starts the new authorization api, new authorization UI and their dependencies to allow running auth locally and having a similar experience as prior creation of the new authorization server api.

On adding the client, some of the tests were failing due to timezone differences.

As part of this I've ensures that times are stored in the Db as UTC and the Db Timestamp is converted to an Instant using a Converter throughout (this was already used in a couple of places).

I've also tidied up a few deprecated annotations for MockBean